### PR TITLE
drop support for node < 14 and other node versions reached EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An Ember [modifier](https://guides.emberjs.com/release/components/template-lifec
 
 - Ember.js v3.12 or above
 - Ember CLI v2.13 or above
-- Node.js v10 or above
+- Node.js v14 or above
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "webpack": "^5.58.2"
   },
   "engines": {
-    "node": "10.* || >= 12"
+    "node": "14.* || 16.* || >= 18"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
Drops support for node 10, 12 and other node versions, which reached end of life (EOL).

This is a breaking change.