### PR TITLE
import hbs from ember-cli-htmlbars in tests

### DIFF
--- a/tests/integration/modifiers/popper-test.js
+++ b/tests/integration/modifiers/popper-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { clearRender, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import td from 'testdouble';
 import { getPopperForElement } from 'ember-popper-modifier';
 

--- a/tests/integration/modifiers/popper-tooltip-test.js
+++ b/tests/integration/modifiers/popper-tooltip-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { find, render } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 import { getPopperForElement } from 'ember-popper-modifier';
 
 module('Integration | Modifier | popper-tooltip', function (hooks) {


### PR DESCRIPTION
Small alignment with default setup of rendering tests in Ember.