### PR TITLE
add basic example in dummy app for manual testing

### DIFF
--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,5 +1,8 @@
 {{page-title "Dummy"}}
 
-<h2 id="title">Welcome to Ember</h2>
+{{!-- template-lint-disable no-inline-styles --}}
+<div style="margin: 0 2em;">
+  <h2 id="title">Welcome to Ember</h2>
 
-{{outlet}}
+  {{outlet}}
+</div>

--- a/tests/dummy/app/templates/components/tool-tip.hbs
+++ b/tests/dummy/app/templates/components/tool-tip.hbs
@@ -1,6 +1,6 @@
 <span
   {{popper-tooltip @attachTo
-    placement="top"
+    placement=(if @placement @placement "top")
     modifiers=(popper-modifier 'offset'
       options=(hash
         offset=(array 0 8)

--- a/tests/dummy/app/templates/components/with-tool-tip.hbs
+++ b/tests/dummy/app/templates/components/with-tool-tip.hbs
@@ -1,7 +1,7 @@
 {{yield this.setReferenceElement this.showTooltip this.hideTooltip}}
 
 {{#if this.tooltipVisible}}
-  <ToolTip @attachTo={{this.referenceElement}} ...attributes>
+  <ToolTip @attachTo={{this.referenceElement}} @placement={{@placement}} ...attributes>
     {{@content}}
   </ToolTip>
 {{/if}}

--- a/tests/dummy/app/templates/index.hbs
+++ b/tests/dummy/app/templates/index.hbs
@@ -1,0 +1,59 @@
+<WithToolTip
+  @content="Tooltip rendered at top"
+  @placement="top"
+  as |register show hide|
+>
+  <button
+    type="button"
+    {{did-insert register}}
+    {{on "mouseover" show}}
+    {{on "mouseleave" hide}}
+  >
+    Hover me!
+  </button>
+</WithToolTip>
+
+<WithToolTip
+  @content="Tooltip rendered at bottom"
+  @placement="bottom"
+  as |register show hide|
+>
+  <button
+    type="button"
+    {{did-insert register}}
+    {{on "mouseover" show}}
+    {{on "mouseleave" hide}}
+  >
+    Hover me!
+  </button>
+</WithToolTip>
+
+<WithToolTip
+  @content="Tooltip rendered on left side"
+  @placement="left"
+  as |register show hide|
+>
+  <button
+    type="button"
+    {{did-insert register}}
+    {{on "mouseover" show}}
+    {{on "mouseleave" hide}}
+  >
+    Hover me!
+  </button>
+</WithToolTip>
+
+<WithToolTip
+  @content="Tooltip rendered on right side"
+  @placement="right"
+  as |register show hide|
+>
+  <button
+    type="button"
+    {{did-insert register}}
+    {{on "mouseover" show}}
+    {{on "mouseleave" hide}}
+  >
+    Hover me!
+  </button>
+</WithToolTip>


### PR DESCRIPTION
Adds a dummy app with a very basic example of rendering tooltips. The showcase is taken from `tests/integration/components/cookbook/tool-tip-test.js`.